### PR TITLE
refactor #150: JWT 제공자 및 필터

### DIFF
--- a/src/main/java/fastcampus/team7/Livable_officener/global/sercurity/JwtAuthenticationFilter.java
+++ b/src/main/java/fastcampus/team7/Livable_officener/global/sercurity/JwtAuthenticationFilter.java
@@ -21,11 +21,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String token = jwtProvider.resolveToken(request);
-
-        if (token != null && jwtProvider.validateToken(token)) {
-            token = token.split(" ")[1].trim();
-            Authentication authentication = jwtProvider.getAuthentication(token);
+        String bearerToken = jwtProvider.resolveToken(request);
+        if (bearerToken != null) {
+            Authentication authentication = jwtProvider.getAuthentication(bearerToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/fastcampus/team7/Livable_officener/global/sercurity/JwtProvider.java
+++ b/src/main/java/fastcampus/team7/Livable_officener/global/sercurity/JwtProvider.java
@@ -25,24 +25,25 @@ import java.util.Date;
 @Slf4j
 public class JwtProvider {
 
-    @Value("${jwt.secret.key}")
-    private String salt;
-
-    private Key secretKey;
-
-    private final long exp = 1000L * 60 * 5;
-
+    private static final long exp = 1000L * 60 * 5;
     private static final String AUTHORIZATION_HEADER = "Authorization";
-
     private static final String BEARER_TOKEN_PREFIX = "Bearer ";
 
-    private final CustomUserDetailsService userDetailsService;
+    @Value("${jwt.secret.key}")
+    private String salt;
+    private Key secretKey;
+    private JwtParser jwtParser;
 
+    private final CustomUserDetailsService userDetailsService;
     private final RedisUtil redisUtil;
 
     @PostConstruct
     protected void init() {
         secretKey = Keys.hmacShaKeyFor(salt.getBytes(StandardCharsets.UTF_8));
+        jwtParser = Jwts
+                .parserBuilder()
+                .setSigningKey(secretKey)
+                .build();
     }
 
     public String createToken(String email) {
@@ -56,26 +57,22 @@ public class JwtProvider {
                 .compact();
     }
 
-    public Authentication getAuthentication(String token) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getEmail(token));
+    public Authentication getAuthentication(String bearerToken) {
+        Jws<Claims> claimsJws = getClaimsJwsByBearerToken(bearerToken);
+        String username = claimsJws.getBody().getSubject();
+        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
         return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
     }
 
     public String getEmail(String token) {
-        return Jwts
-                .parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
+        return jwtParser
                 .parseClaimsJws(token)
                 .getBody()
                 .getSubject();
     }
 
     public Long getExpirationTime(String token) {
-        return Jwts
-                .parserBuilder()
-                .setSigningKey(secretKey)
-                .build()
+        return jwtParser
                 .parseClaimsJws(token)
                 .getBody()
                 .getExpiration()
@@ -83,7 +80,6 @@ public class JwtProvider {
     }
 
     /**
-     *
      * @param request HttpServletRequest
      * @return "Authorization" 헤더에서 "Bearer {token} 형식으로 추출
      */
@@ -91,34 +87,42 @@ public class JwtProvider {
         return request.getHeader(AUTHORIZATION_HEADER);
     }
 
-    /**
-     *
-     * @param token "Bearer {token}" 형식
-     * @return accessToken 을 추출
-     */
-    public String getBearerTokenPrefix(String token) {
-        String accessToken = token.split(" ")[1].trim();
-        return accessToken;
+//    public Authentication resolveAuthentication(StompHeaderAccessor accessor) {
+//        String token = Objects.requireNonNull(accessor.getNativeHeader(AUTHORIZATION_HEADER)).get(0);
+//        if (validateToken(token)) {
+//            token = token.split(" ")[1].trim();
+//            return getAuthentication(token);
+//        }
+//        throw new IllegalArgumentException("STOMP JWT 인증 실패");
+//    }
+
+    public Jws<Claims> getClaimsJwsByBearerToken(String bearerToken) {
+        String accessToken = parseAccessToken(bearerToken);
+        return getClaimsJwsByAccessToken(accessToken);
     }
 
-    public boolean validateToken(String token) {
+    /**
+     * @param bearerToken "Bearer {token}" 형식
+     * @return accessToken 을 추출
+     */
+    public String parseAccessToken(String bearerToken) {
+        if (!bearerToken.startsWith(BEARER_TOKEN_PREFIX)) {
+            throw new IllegalArgumentException("Bearer 토큰이 아닙니다.");
+        }
+        return bearerToken.split(" ")[1].trim();
+    }
+
+    public Jws<Claims> getClaimsJwsByAccessToken(String accessToken) {
+        if (redisUtil.hasBlackList(accessToken)) {
+            throw new AlreadyLogoutException(FilterExceptionCode.ALREADY_LOGGED_OUT);
+        }
+
         try {
-            if (!token.startsWith(BEARER_TOKEN_PREFIX)) {
-                return false;
+            Jws<Claims> claimsJws = jwtParser.parseClaimsJws(accessToken);
+            if (!claimsJws.getBody().getExpiration().before(new Date())) {
+                throw new ExpiredJwtException(claimsJws.getHeader(), claimsJws.getBody(), "유효기간 지난 토큰");
             }
-            String accessToken = getBearerTokenPrefix(token);
-
-            if (redisUtil.hasBlackList(accessToken)) {
-                throw new AlreadyLogoutException(FilterExceptionCode.ALREADY_LOGGED_OUT);
-            }
-
-            Jws<Claims> claims = Jwts
-                    .parserBuilder()
-                    .setSigningKey(secretKey)
-                    .build()
-                    .parseClaimsJws(accessToken);
-
-            return !claims.getBody().getExpiration().before(new Date());
+            return claimsJws;
         } catch (SignatureException e) {
             log.info("JwtProvider SignatureException 예외 발생");
             throw new JwtException(FilterExceptionCode.WRONG_TYPE_TOKEN.getMessage());
@@ -133,6 +137,5 @@ public class JwtProvider {
             throw new JwtException(FilterExceptionCode.UNKNOWN_ERROR.getMessage());
         }
     }
-
 
 }


### PR DESCRIPTION
- JwtParser 추출
- validate 대신 get으로 바꿔서 중복 코드 활용
  - boolean을 반환하지 않고 원하는 결과를 반환하되 기존 false 로직일 경우 예외 반환
- 로직 분할
- 위 변경점에 따른 로직 수정
---
슬랙으로 말씀드린 부분 리팩토링 해보았는데 한 번 리뷰해주시면 감사하겠습니다 ㅎㅎ!

참고로 Bearer 파싱하고나서 getClaimsJwsByAccessToken 으로 로직 분할한 이유는 웹소켓 보안 쪽에서도 토큰 인증이 필요하기 때문입니다..!