### PR TITLE
hotfix #194: JPA 동작 시 시간대 KST 고정 코드 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,8 @@ spring:
       hibernate:
         ddl-auto: true
         format_sql: true
+        jdbc:
+          time_zone: Asia/Seoul
   sql:
     init:
       data-locations: classpath*:data.sql


### PR DESCRIPTION
* JPA 동작 시간대 KST 고정
* DB 엔드포인트에 시간대 파라미터 추가 -> 수동 변경 요청